### PR TITLE
Bump GT-5 API and use newer localization call for ore names.

### DIFF
--- a/src/main/java/com/detrav/commands/DetravScannerCommand.java
+++ b/src/main/java/com/detrav/commands/DetravScannerCommand.java
@@ -1,6 +1,7 @@
 package com.detrav.commands;
 
 import gregtech.api.GregTech_API;
+import gregtech.api.enums.Materials;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.common.blocks.GT_TileEntity_Ores;
 import net.minecraft.block.Block;
@@ -107,8 +108,9 @@ public class DetravScannerCommand implements ICommand {
                         TileEntity entity = c.getTileEntityUnsafe(x, y, z);
                         if (entity != null) {
                             GT_TileEntity_Ores gt_entity = (GT_TileEntity_Ores) entity;
-                            String name = GT_LanguageManager.getTranslation(
-                                    b.getUnlocalizedName() + "." + gt_entity.getMetaData() + ".name");
+                            short meta = gt_entity.getMetaData();
+                            String name = Materials.getLocalizedNameForItem(
+                            		GT_LanguageManager.getTranslation(b.getUnlocalizedName() + "." + meta + ".name"), meta);
                             if(name.startsWith("Small")) continue;
                             if (fName == null || name.toLowerCase().contains(fName)) {
                                 if (!ores.containsKey(name))

--- a/src/main/java/com/detrav/items/behaviours/BehaviourDetravToolProPick.java
+++ b/src/main/java/com/detrav/items/behaviours/BehaviourDetravToolProPick.java
@@ -78,7 +78,8 @@ public class BehaviourDetravToolProPick extends Behaviour_None {
         if (aTileEntity != null) {
             if (aTileEntity instanceof GT_TileEntity_Ores) {
                 GT_TileEntity_Ores gt_entity = (GT_TileEntity_Ores) aTileEntity;
-                String name = GT_LanguageManager.getTranslation("gt.blockores." + gt_entity.getMetaData() + ".name");
+                short meta = gt_entity.getMetaData();
+                String name = Materials.getLocalizedNameForItem(GT_LanguageManager.getTranslation("gt.blockores." + meta + ".name"), meta);
                 addChatMassageByValue(aPlayer, -1, name);
                 if (!aPlayer.capabilities.isCreativeMode)
                     aItem.doDamage(aStack, this.mCosts);
@@ -117,9 +118,8 @@ public class BehaviourDetravToolProPick extends Behaviour_None {
                                     && ((GT_TileEntity_Ores) tTileEntity).mNatural == true) {
                                 tMetaID = (short)((GT_TileEntity_Ores) tTileEntity).getMetaData();
                                 try {
-
-                                    String name = GT_LanguageManager.getTranslation(
-                                            tBlock.getUnlocalizedName() + "." + tMetaID + ".name");
+                                    String name = Materials.getLocalizedNameForItem(
+                                    		GT_LanguageManager.getTranslation(tBlock.getUnlocalizedName() + "." + tMetaID + ".name"), tMetaID);
                                     if (name.startsWith("Small")) if (data != 1) continue;
                                     if (name.startsWith("Small")) if(data!=1) continue;
                                     if (!ores.containsKey(name))
@@ -147,8 +147,9 @@ public class BehaviourDetravToolProPick extends Behaviour_None {
                                 try {
                                     try {
                                         tMetaID = (short)tAssotiation.mMaterial.mMaterial.mMetaItemSubID;
-                                        String name = GT_LanguageManager.getTranslation(
-                                                "gt.blockores." + tMetaID + ".name");
+                                        
+                                        String name = Materials.getLocalizedNameForItem(GT_LanguageManager.getTranslation(
+                                                "gt.blockores." + tMetaID + ".name"), tMetaID);
                                         if (!ores.containsKey(name))
                                             ores.put(name, 1);
                                         else {

--- a/src/main/java/com/detrav/net/DetravProPickPacket00.java
+++ b/src/main/java/com/detrav/net/DetravProPickPacket00.java
@@ -147,7 +147,7 @@ public class DetravProPickPacket00 extends DetravPacket {
                             }
                             rgba = tMaterial.getRGBA();
                             //ores.put(GT_Ore)
-                            name = GT_LanguageManager.getTranslation("gt.blockores." + meta + ".name");
+                            name = tMaterial.getLocalizedNameForItem(GT_LanguageManager.getTranslation("gt.blockores." + meta + ".name"));
 
                             raster.setSample(i, j, 0, rgba[0]);
                             raster.setSample(i, j, 1, rgba[1]);


### PR DESCRIPTION
Grabbed latest gregtech-dev from [jenkins]( http://jenkins.usrv.de:8081/job/Gregtech-5-Unofficial/lastSuccessfulBuild/artifact/build/libs/gregtech-5.09.32.09-dev.jar)

Updated name displayed on the scanner to use the localized name instead of %material.