### PR TITLE
Buff Prospector's Scanner Durability

### DIFF
--- a/src/main/java/com/detrav/items/tools/DetravProspector.java
+++ b/src/main/java/com/detrav/items/tools/DetravProspector.java
@@ -28,6 +28,6 @@ public class DetravProspector extends DetravToolElectricProspectorBase {
 	    }
 	    
 	    public void onStatsAddedToTool(GT_MetaGenerated_Tool aItem, int aID) {
-	        aItem.addItemBehavior(aID, new BehaviourDetravToolProspector(100));
+	        aItem.addItemBehavior(aID, new BehaviourDetravToolProspector(15));
 	    }
 }


### PR DESCRIPTION
- Changed the durability loss per scanned chunk from 100 to 15. This increases the total durability of all non-electric prospector scanners by around 6,666... times.

| Material and Tier | Durability after 1 use | % of Total Dur. | Avg. Uses | Scan Area | Max. Veins Scanned | Scan Chance | Average Veins Scanned | Average after Change
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Vanadiumsteel LV | 4550/5000 | 91% | 11 uses | 3x3 | 44 veins | 24% | 10.56 | 70.4
| Vanadiumsteel MV | 7950/8400 | 95% | 20 uses | 3x3 | 80 veins | 40% | 32 | 213.33
| Vibrant Alloy HV | 27875/29400 | 95% | 20 uses | 5x5 | 80 veins | 56% | 44.8 | 298.66
| Shadow Metal EV | 94150/98000 | 96% | 25 uses | 7x7 | 225 veins | 72% | 162 | 1080
| Oriharukon IV | 196575/201100 | 98% | 50 uses | 7x7 | 450 veins | 88% | 396 | 2640

The non-electric, early game Prospector's Scanners weren't used by anyone, and the questbook itself says they're bad. This is because they have a lot of flaws, including the fact they only show nearby veins in the chat and the player has to write it all down, which is much worse than the Seismic Prospector's books that keep it written down and show the coordinates of the veins. However, the visual prospecting change made it so these scanners create precise waypoints of the veins, a great upgrade that would make them worthwhile if not for their awful durability, and consquent amount of veins scanned for their cost.

I'm currently at EV, and I feel like there should be an intermediate step because the Ore Wand, slow and limited scanning of one kind of ore vein at a time, and LuV, where the electric prospector scan very quickly and can be easily recharged to use as much as you want. I used a good material, Shadow Metal, which is locked behind Thaumcraft progression, but I still could only scan 162 veins on average after spending some circuits and an EV Sensor, which I thought was a tiny amount. After this change, it would be possible to scan 1080 veins on average, after the % chance of a successful scan. I believe it's a good, long-lasting amount of easy scans, but still limited, unlike the electric scanners available at LuV and up.
